### PR TITLE
Fixes #6

### DIFF
--- a/ColoredDamageTypes.cs
+++ b/ColoredDamageTypes.cs
@@ -142,7 +142,7 @@ namespace ColoredDamageTypes
                 {
 					ColoredDamageTypes.Log("Found modded damage type! " + itemToCheck.DamageType.FullName.ToString());
 
-					string dcname = itemToCheck.DamageType.ToString();
+					string dcname = itemToCheck.DamageType.FullName.ToString();
 					zCrossModConfig.DamageType dt = new zCrossModConfig.DamageType(dcname, new Color(255, 255, 255), new Color(255, 160, 80), new Color(255, 100, 30));
 					zCrossModConfig.CrossModDamageConfig_Orig.Add(dcname, dt);
 


### PR DESCRIPTION
There are further misuses of ToString than the one shown here.
Please adhere to the design of the mod loader rather than assuming one damage type per class.